### PR TITLE
Respect the `space-before-function-paren` rule

### DIFF
--- a/snippets/functions.cson
+++ b/snippets/functions.cson
@@ -5,7 +5,7 @@
   "named function":
     prefix: "fn"
     body: """
-    function ${1:name}(${2:arguments}) {
+    function ${1:name} (${2:arguments}) {
     \t${0}
     }
     """


### PR DESCRIPTION
`fn` snippet produces function declaration, which contradicts the `space-before-function-paren` eslint rule.

``` diff
-function name(arguments) {
+function name (arguments) {
    // Function body...
}
```
