### PR TITLE
changed vre to cre

### DIFF
--- a/snippets/node-modules.cson
+++ b/snippets/node-modules.cson
@@ -2,9 +2,9 @@
   "require":
     prefix: "re"
     body: "require('${1:module}')"
-  "var module = require('module')":
-    prefix: "vre"
-    body: "var ${1:module} = require('${1:module}')"
+  "const module = require('module')":
+    prefix: "cre"
+    body: "const ${1:module} = require('${1:module}')"
   "exports.member":
     prefix: "em"
     body: "exports.${1:member} = ${2:value}"


### PR DESCRIPTION
modules are always constants. Declaring them with var only makes sense in node.js 0.12 and lesser where const isn't available.
This plugin is described as "A collection of ES6 snippets for faster JavaScript development" in the main readme so I think it is okay to promote the best practices incompatible with 0.12. Most people using this collection of snippets are already on newer node.js than 0.12 where I would consider declaring modules with let a bad practice.
